### PR TITLE
docs: guidance on building locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,33 @@ SERVEIT can be configuring via environment variables:
 | `SERVEIT_ROOT_DIR`  | `/app/web` | The root directory of files to serve.                        |
 | `SERVEIT_PORT`      | `"4000"`   | The port to serve on.                                        |
 | `SERVEIT_LOG_LEVEL` | `"INFO"`   | The level to log at (`ALL` == everything; `OFF` == nothing). |
+
+## DEVELOPING
+
+### PREREQUISITES
+
+To build `serveit` locally, the following tools must be available in your `PATH`:
+
+* [Deno](https://deno.land/), v2.0.0 or later
+* [Crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) v0.19.0 or later
+* [Task](https://taskfile.dev/), v3.30.0 or later
+
+In addition, Docker v25 or later is required to be installed and running.
+
+It is possible to obtain these using an [installer script](./.github/scripts/install-tooling.sh) for most of these dependencies (plus others needed by GitHub Actions for publishing and distritubing).  By default the script installs tools in `${HOME}/bin`.
+
+### WORKING COPY
+
+This repository uses git modules for some build instructions.  Be sure to clone with recursive submodules to have all the necessary files:
+
+```
+git clone --recurse-submodules https://github.com/o-p-n/serveit
+```
+
+### TESTING
+
+Run `task test` to execute all unit-tests. Run `task cover` to generate code coverage reports (including HTML); coverage reports are stored in `./coverage/html` in your working copy. 
+
+### BUILDING IMAGES
+
+Run `task image` to build the container image.  This is a multi-arch image, with both `linux/amd64` and `linux/arm64`.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ docker run <options> \
     gcr.io/o-p-n/serveit:<TAG>
 ```
 
+### IMAGES
+
+Releases can be found at the [`serveit` container package](https://github.com/o-p-n/serveit/pkgs/container/serveit).  Generally, each release is tagged with its corresponding git commit hash.  There is no `latest` tag, currently.
+
+The following platforms are supported:
+
+* `linux/amd64`
+* `linux/arm64`
+
 ### CONFIGURING
 
 SERVEIT can be configuring via environment variables:

--- a/README.md
+++ b/README.md
@@ -41,10 +41,13 @@ To build `serveit` locally, the following tools must be available in your `PATH`
 * [Deno](https://deno.land/), v2.0.0 or later
 * [Crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) v0.19.0 or later
 * [Task](https://taskfile.dev/), v3.30.0 or later
+* [Docker](https://docker.com/), v25 or later
 
-In addition, Docker v25 or later is required to be installed and running.
+It is possible to obtain most of these (excluding Docker) using an [installer script](./.github/scripts/install-tooling.sh) for most of these dependencies (plus others needed by GitHub Actions for publishing and distritubing).  By default the script installs tools in `${HOME}/bin`.
 
-It is possible to obtain these using an [installer script](./.github/scripts/install-tooling.sh) for most of these dependencies (plus others needed by GitHub Actions for publishing and distritubing).  By default the script installs tools in `${HOME}/bin`.
+In addition, git hooks are managed using [Lefthook](https://github.com/evilmartians/lefthook).  It currently has the following hooks:
+
+* `pre-push` — runs code styling checks (linting and format-checking)
 
 ### WORKING COPY
 

--- a/deno.json
+++ b/deno.json
@@ -12,6 +12,12 @@
     "@std/path": "jsr:@std/path@^0.225.2"
   },
   "fmt": {
-    "exclude": ["README.md"]
+    "exclude": [
+      ".cache/**",
+      ".task/**",
+      "coverage/**",
+      "target/**",
+      "README.md"
+    ]
   }
 }


### PR DESCRIPTION
Document where to find existing container image tags, as well as how to test and build locally.

related #37 