### PR TITLE
fix: out-of-tree data exposure possible 

### DIFF
--- a/src/file-server.ts
+++ b/src/file-server.ts
@@ -11,7 +11,7 @@ import {
   MethodNotAllowed,
   NotFound,
 } from "./errors.ts";
-import { common, join } from "@std/path";
+import { common, resolve } from "@std/path";
 
 const ALLOWED_METHODS = [
   "GET",
@@ -107,7 +107,7 @@ export class Server {
     etags?: string,
     preview = false,
   ): Promise<Response> {
-    path = join(this.config.rootDir, path);
+    path = resolve(this.config.rootDir, path);
     if (common([this.rootDir, path]) !== this.rootDir) {
       log().warn`invalid path requested: ${path}`;
       return new NotFound().toResponse();

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, it } from "./deps.ts";
 import { expect, mock } from "./deps.ts";
 
-import { resolve, normalize } from "@std/path";
+import { resolve } from "@std/path";
 
 import { _internals, load } from "../src/config.ts";
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, it } from "./deps.ts";
 import { expect, mock } from "./deps.ts";
 
-import { join, normalize } from "@std/path";
+import { resolve, normalize } from "@std/path";
 
 import { _internals, load } from "../src/config.ts";
 
@@ -44,9 +44,7 @@ describe("config", () => {
         return p;
       }
 
-      return normalize(
-        join("/app/web", p),
-      );
+      return resolve("/app/web", p);
     };
     spyResolve = mock.stub(_internals, "resolve", fn);
   });


### PR DESCRIPTION
The filesystem path is not normalized before attempting to locate and open a file, which could allow relative path segments in the URL path to load files outside of the `SERVEIT_DIR` directory tree.

fixes #43